### PR TITLE
Js Lint

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var buffer = require('vinyl-buffer');
 var uglify = require('gulp-uglify');
 var sourcemaps = require('gulp-sourcemaps');
 var plumber = require('gulp-plumber');
+var jshint = require('gulp-jshint');
 
 gulp.task('sass', function() {
   return gulp.src('public/css/main.sass')
@@ -18,9 +19,16 @@ gulp.task('sass', function() {
     .pipe(gulp.dest('public/css'));
 });
 
-gulp.task('watch', function() {
-  gulp.watch('public/css/**/*.sass', ['sass']);
+gulp.task('lint', function() {
+  return gulp.src('./**/*.js')
+    .pipe(jshint())
+    .pipe(jshint.reporter('default'));
 });
 
-gulp.task('build', ['sass']);
+gulp.task('watch', function() {
+  gulp.watch('public/css/**/*.sass', ['sass']);
+  gulp.watch('./**/*.js', ['lint']);
+});
+
+gulp.task('build', ['sass', 'lint']);
 gulp.task('default', ['build', 'watch']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var uglify = require('gulp-uglify');
 var sourcemaps = require('gulp-sourcemaps');
 var plumber = require('gulp-plumber');
 var jshint = require('gulp-jshint');
+var jscs = require('gulp-jscs');
 
 gulp.task('sass', function() {
   return gulp.src('public/css/main.sass')
@@ -19,11 +20,21 @@ gulp.task('sass', function() {
     .pipe(gulp.dest('public/css'));
 });
 
-gulp.task('lint', function() {
+gulp.task('jshint', function() {
   return gulp.src('./**/*.js')
+    .pipe(plumber())
     .pipe(jshint())
     .pipe(jshint.reporter('default'));
 });
+
+gulp.task('jscs', function() {
+  return gulp.src('./**/*.js')
+    .pipe(plumber())
+    .pipe(jscs())
+    .pipe(jscs.reporter());
+});
+
+gulp.task('lint', ['jshint', 'jscs']);
 
 gulp.task('watch', function() {
   gulp.watch('public/css/**/*.sass', ['sass']);

--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "gulp": "^3.9.1",
+    "gulp-jscs": "^3.0.2",
     "gulp-jshint": "^2.0.1",
+    "jscs": "^3.0.4",
     "jshint": "^2.9.2",
     "mocha": "^2.4.5",
     "sinon": "^1.17.3",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "gulp": "^3.9.1",
+    "gulp-jshint": "^2.0.1",
+    "jshint": "^2.9.2",
     "mocha": "^2.4.5",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",


### PR DESCRIPTION
Using [jshint](jshint.com) and [JSCS](http://jscs.info/) for JavaScript linting.

@jmcoimbra I've spotted a problem, [JSCS was merged on ESLint](https://medium.com/@markelog/jscs-end-of-the-line-bc9bf0b3fdb2), so it won't be maintained anymore.
