### PR TITLE
JShint reporter style and Sourcemaps

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,9 +14,13 @@ var jscs = require('gulp-jscs');
 gulp.task('sass', function() {
   return gulp.src('public/css/main.sass')
     .pipe(plumber())
+    .pipe(sourcemaps.init())
     .pipe(sass())
+    .pipe(sourcemaps.write({includeContent: false}))
+    .pipe(sourcemaps.init({loadMaps: true}))
     .pipe(autoprefixer())
     .pipe(gulpif(argv.production, csso()))
+    .pipe(sourcemaps.write())
     .pipe(gulp.dest('public/css'));
 });
 
@@ -24,7 +28,7 @@ gulp.task('jshint', function() {
   return gulp.src('./**/*.js')
     .pipe(plumber())
     .pipe(jshint())
-    .pipe(jshint.reporter('default'));
+    .pipe(jshint.reporter('jshint-stylish'));
 });
 
 gulp.task('jscs', function() {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "gulp-jshint": "^2.0.1",
     "jscs": "^3.0.4",
     "jshint": "^2.9.2",
+    "jshint-stylish": "^2.2.0",
     "mocha": "^2.4.5",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",


### PR DESCRIPTION
- Changing the jshint reporter to jshint-stylish for a better look
- Enabling sourcemaps for sass files
