### PR TITLE
Sourcemaps wasn't working.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,7 @@ gulp.task('sass', function() {
     .pipe(sourcemaps.init({loadMaps: true}))
     .pipe(autoprefixer())
     .pipe(gulpif(argv.production, csso()))
-    .pipe(sourcemaps.write())
+    .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('public/css'));
 });
 


### PR DESCRIPTION
Fixed adding a '.' to sourcemaps.write function.
