### PR TITLE
Feature/gulp spawn mocha

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var sourcemaps = require('gulp-sourcemaps');
 var plumber = require('gulp-plumber');
 var jshint = require('gulp-jshint');
 var eslint = require('gulp-eslint');
+var mocha = require('gulp-spawn-mocha');
 
 gulp.task('sass', function() {
   return gulp.src('public/css/main.sass')
@@ -37,11 +38,18 @@ gulp.task('eslint', function() {
     .pipe(eslint.failAfterError());
 });
 
+gulp.task('test', function() {
+  return gulp.src(['./**/*.js', '!node_modules/**'])
+    .pipe(plumber())
+    .pipe(mocha({
+      env: {NODE_ENV: 'test'}}));
+});
+
 gulp.task('lint', ['jshint', 'eslint']);
 
 gulp.task('watch', function() {
   gulp.watch('public/css/**/*.sass', ['sass']);
-  gulp.watch('./**/*.js', ['lint']);
+  gulp.watch('./**/*.js', ['lint', 'test']);
 });
 
 gulp.task('build', ['sass', 'lint']);

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "gulp": "^3.9.1",
     "gulp-eslint": "^2.0.0",
     "gulp-jshint": "^2.0.1",
+    "gulp-spawn-mocha": "^2.2.2",
     "jshint": "^2.9.2",
     "jshint-stylish": "^2.2.0",
     "mocha": "^2.4.5",

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,7 +1,6 @@
 /* global it, describe, before */
 var request = require('supertest');
 var server = require('../server');
-// var should = require('chai').should();
 var expect = require('chai').expect;
 var Browser = require('zombie');
 
@@ -16,7 +15,7 @@ describe('User visits the main page', function() {
       if (err) {
         return done(err);
       }
-      res.text.should.have.match(/Donec id elit non/);
+      expect(res.text).to.have.match(/Donec id elit non/);
       done();
     });
   });
@@ -31,7 +30,7 @@ describe('User visits the contact page', function() {
       if (err) {
         return done(err);
       }
-      res.text.should.have.match(/Contact Form/);
+      expect(res.text).to.have.match(/Contact Form/);
       done();
     });
   });


### PR DESCRIPTION
Using package `gulp-spawn-mocha` so we can auto run the test bench when a javascript file changes with `gulp watch`.

Closes #13 
